### PR TITLE
Update Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -8,8 +8,7 @@ ENV PATH /opt/node-v18.12.1-linux-x64/bin:$PATH
 WORKDIR /www/ui
 COPY . /www/ui
 
-RUN npm install
-RUN npm run build
+RUN npm install && npm run build && rm -rf node_modules
 
 FROM nginx:1.17
 


### PR DESCRIPTION
This is not really tested but we should try and minimize the size of intermediate build layers, this way the node_modules folder which is around 600mb doesn't make it as part of the final image