### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 models/
 docker-volumes/
-
+node_modules/


### PR DESCRIPTION
As discussed earlier, we should not include the local node_modules folder in the directory tree for the docker build